### PR TITLE
Fix sending invoice after successful payment

### DIFF
--- a/Service/TpayService.php
+++ b/Service/TpayService.php
@@ -170,8 +170,8 @@ class TpayService extends RegisterCaptureNotificationOperation
         $order->setStatus($status)->setState($status)->save();
         if ($sendNewInvoiceMail) {
             foreach ($order->getInvoiceCollection() as $invoice) {
-                $invoice_id = $invoice->getIncrementId();
-                $this->invoiceService->notify($invoice_id);
+                $invoiceId = $invoice->getId();
+                $this->invoiceService->notify($invoiceId);
             }
         }
 


### PR DESCRIPTION
## Issue description

An invoice email is not sent automatically after successful payment. An exception is occurring, which is being supressed somewhere in the call stack and not logged anywhere. The error message thrown is:
```
The entity that was requested doesn't exist. Verify the entity and try again.
```

The issue is thrown in ``vendor/magento/module-sales/Model/Order/InvoiceRepository.php:75`` because ``increment_id`` of an invoice is used to retrieve it instead of ``entity_id``.

## Magento version

Occurred in Magento 2.3.3 Community. Unless the ``vendor/magento/module-sales/Model/Service/InvoiceService::notify`` implementation was changed recently, the issue will occur in earlier versions as well.

## Steps to reproduce
In Magento config set the flag for sending an invoice automatically to Yes. Then make a payment. The invoice should be sent via email to the customer but it's not.
